### PR TITLE
Added support for operating voltage for RemoteIP devices

### DIFF
--- a/pyhomematic/devicetypes/misc.py
+++ b/pyhomematic/devicetypes/misc.py
@@ -2,7 +2,7 @@ import logging
 from pyhomematic.devicetypes.generic import HMDevice
 from pyhomematic.devicetypes.helper import HelperActionPress, \
     HelperEventRemote, HelperEventPress, HelperRssiPeer, HelperLowBatIP, \
-    HelperLowBat
+    HelperLowBat, HelperOperatingVoltageIP
 
 LOG = logging.getLogger(__name__)
 
@@ -61,7 +61,7 @@ class Remote(HMEvent, HelperEventRemote, HelperActionPress, HelperRssiPeer):
         return [1]
 
 
-class RemoteBatteryIP(Remote, HelperLowBatIP):
+class RemoteBatteryIP(Remote, HelperLowBatIP, HelperOperatingVoltageIP):
     """Battery operated HomeMaticIP remote device."""
 
 


### PR DESCRIPTION
This pull request adds support to see the operating voltage for Remote IP devices. Tested with WRC2 and WRCC2
